### PR TITLE
Randomized Features Hot Fix

### DIFF
--- a/Lucid_Somnambulist/somn/build/assemble.py
+++ b/Lucid_Somnambulist/somn/build/assemble.py
@@ -347,7 +347,8 @@ def randomize_features(feat: np.ndarray):
     """
     # feat_ = feat
     rng = np.random.default_rng()
-    feats = rng.random(out=feat)
+    feats = rng.random(size=feat.size)
+    feats = feats.reshape(feat.shape)
     return feats
 
 


### PR DESCRIPTION
`out=feat` overwrote the original real feature array as well as returned it. This fixes that problem